### PR TITLE
Catppuccin Macchiato Flavor

### DIFF
--- a/theme/flavors/catppuccin-macchiato.theme.css
+++ b/theme/flavors/catppuccin-macchiato.theme.css
@@ -14,13 +14,14 @@
 @import url('https://refact0r.github.io/system24/src/main.css'); /* main theme css. DO NOT REMOVE */
 @import url('https://refact0r.github.io/system24/src/unrounding.css'); /* gets rid of all rounded corners. remove if you want rounded corners. */
 
+
 /* customize things here */
 :root {
 	--font: 'DM Mono'; /* UI font name. it must be installed on your system. */
 	letter-spacing: -0.05ch; /* decreases letter spacing for better readability. */
 	font-weight: 300; /* UI font weight. */
 	--label-font-weight: 500; /* font weight for panel labels. */
-	--corner-text: 'catppuccin24'; /* custom text to display in the corner. only works on windows. */
+	--corner-text: 'macchiato24'; /* custom text to display in the corner. only works on windows. */
 	--pad: 16px; /* padding between panels. */
 	--txt-pad: 10px; /* padding inside panels to prevent labels from clipping */
 	--panel-roundness: 0px; /* corner roundness of panels. ONLY WORKS IF unrounding.css IS REMOVED (see above). */

--- a/theme/flavors/catppuccin-macchiato.theme.css
+++ b/theme/flavors/catppuccin-macchiato.theme.css
@@ -1,0 +1,87 @@
+/**
+ * @name system24 (catppuccin macchiato lavender)
+ * @description A tui-style discord theme. Based on the catppuccin maccchiato color palette.
+ * @author refact0r
+ * @version 1.0.0
+ * @invite nz87hXyvcy
+ * @website https://github.com/refact0r/system24
+ * @source https://github.com/refact0r/system24/blob/master/flavors/catppuccin-mocha.theme.css 
+ * @authorId 508863359777505290
+ * @authorLink https://www.refact0r.dev
+*/
+
+/* import theme modules */
+@import url('https://refact0r.github.io/system24/src/main.css'); /* main theme css. DO NOT REMOVE */
+@import url('https://refact0r.github.io/system24/src/unrounding.css'); /* gets rid of all rounded corners. remove if you want rounded corners. */
+
+/* customize things here */
+:root {
+	--font: 'DM Mono'; /* UI font name. it must be installed on your system. */
+	letter-spacing: -0.05ch; /* decreases letter spacing for better readability. */
+	font-weight: 300; /* UI font weight. */
+	--label-font-weight: 500; /* font weight for panel labels. */
+	--corner-text: 'catppuccin24'; /* custom text to display in the corner. only works on windows. */
+	--pad: 16px; /* padding between panels. */
+	--txt-pad: 10px; /* padding inside panels to prevent labels from clipping */
+	--panel-roundness: 0px; /* corner roundness of panels. ONLY WORKS IF unrounding.css IS REMOVED (see above). */
+
+	/* background colors */
+	--bg-0: #24273a; /* main background color. */
+	--bg-1: #1e2030; /* background color for secondary elements like code blocks, embeds, etc. */
+	--bg-2: #363a4f; /* color of neutral buttons. */
+	--bg-3: #494d64; /* color of neutral buttons when hovered. */
+
+	/* state modifiers */
+	--hover: color-mix(in oklch, var(--txt-3), transparent 80%); /* color of hovered elements. */
+	--active: color-mix(in oklch, var(--txt-3), transparent 60%); /* color of elements when clicked. */
+	--selected: var(--active); /* color of selected elements. */
+
+	/* text colors */
+	--txt-dark: var(--bg-0); /* color of dark text on colored backgrounds. */
+	--txt-link: var(--cyan); /* color of links. */
+	--txt-0: #eaeefa; /* color of bright/white text. */
+	--txt-1: #cad3f5; /* main text color. */
+	--txt-2: #939ab7; /* color of secondary text like channel list. */
+	--txt-3: #5b6078; /* color of muted text. */
+
+	/* accent colors */
+	--acc-0: var(--lavender); /* main accent color. */
+	--acc-1: var(--lavender-1); /* color of accent buttons when hovered. */
+	--acc-2: var(--lavender-2); /* color of accent buttons when clicked. */
+
+	/* borders */
+	--border-width: 2px; /* panel border thickness. */
+	--border-color: var(--bg-2); /* panel border color. */
+	--border-hover-color: var(--acc-0); /* panel border color when hovered. */
+	--border-transition: 0.2s ease; /* panel border transition. */
+
+	/* status dot colors */
+	--online-dot: var(--cyan); /* color of online dot. */
+	--dnd-dot: var(--pink); /* color of do not disturb dot. */
+	--idle-dot: var(--yellow); /* color of idle dot. */
+	--streaming-dot: var(--purple); /* color of streaming dot. */
+
+	/* mention/ping and message colors */
+	--mention-txt: var(--acc-0); /* color of mention text. */
+	--mention-bg: color-mix(in oklch, var(--acc-0), transparent 90%); /* background highlight of mention text. */
+	--mention-overlay: color-mix(in oklch, var(--acc-0), transparent 90%); /* overlay color of messages that mention you. */
+	--mention-hover-overlay: color-mix(in oklch, var(--acc-0), transparent 95%); /* overlay color of messages that mention you when hovered. */
+	--reply-overlay: var(--active); /* overlay color of message you are replying to. */
+	--reply-hover-overlay: var(--hover); /* overlay color of message you are replying to when hovered. */
+
+	/* color shades */
+	--pink: #f38ba8;
+	--pink-1: #d16c89;
+	--pink-2: #af4e6c;
+	--purple: #cba6f7;
+	--purple-1: #ab87d6;
+	--purple-2: #8d69b5;
+	--cyan: #74c7ec;
+	--yellow: #f9e2af;
+	--green: #a6e3a1;
+	--green-1: #87c282;
+	--green-2: #68a364;
+	--lavender: #b4befe;
+	--lavender-1: #a6afe9;
+	--lavender-2: #9aa3e0;
+}

--- a/theme/flavors/catppuccin-macchiato.theme.css
+++ b/theme/flavors/catppuccin-macchiato.theme.css
@@ -70,18 +70,18 @@
 	--reply-hover-overlay: var(--hover); /* overlay color of message you are replying to when hovered. */
 
 	/* color shades */
-	--pink: #ed8796;
-	--pink-1: #cb6878;
-	--pink-2: #a94a5b;
-	--purple: #c6a0f6;
-	--purple-1: #a781d4;
-	--purple-2: #8863b4;
-	--cyan: #7dc4e4;
-	--yellow: #eed49f;
-	--green: #a6da95;
-	--green-1: #87ba76;
-	--green-2: #699a58;
-	--lavender: #b4befe;
-	--lavender-1: #959edc;
-	--lavender-2: #7780bc;
+	--pink: oklch(73.7% 0.125 11.19);
+	--pink-1: oklch(63.7% 0.125 11.19);
+	--pink-2: oklch(53.7% 0.125 11.19);
+	--purple: oklch(77.15% 0.126 303.9);
+	--purple-1: oklch(67.15% 0.126 303.9);
+	--purple-2: oklch(57.15% 0.126 303.9);
+	--cyan: oklch(78.51% 0.085 228.38);
+	--yellow: oklch(87.9% 0.074 84.75);
+	--green: oklch(83.5% 0.108 138.15);
+	--green-1: oklch(73.5% 0.108 138.15);
+	--green-2: oklch(63.5% 0.108 138.15);
+	--lavender: oklch(81.66% 0.091 277.31);
+	--lavender-1: oklch(71.66% 0.091 277.31);
+	--lavender-2: oklch(61.66% 0.091 277.31);
 }

--- a/theme/flavors/catppuccin-macchiato.theme.css
+++ b/theme/flavors/catppuccin-macchiato.theme.css
@@ -14,7 +14,6 @@
 @import url('https://refact0r.github.io/system24/src/main.css'); /* main theme css. DO NOT REMOVE */
 @import url('https://refact0r.github.io/system24/src/unrounding.css'); /* gets rid of all rounded corners. remove if you want rounded corners. */
 
-
 /* customize things here */
 :root {
 	--font: 'DM Mono'; /* UI font name. it must be installed on your system. */
@@ -71,18 +70,18 @@
 	--reply-hover-overlay: var(--hover); /* overlay color of message you are replying to when hovered. */
 
 	/* color shades */
-	--pink: #f38ba8;
-	--pink-1: #d16c89;
-	--pink-2: #af4e6c;
-	--purple: #cba6f7;
-	--purple-1: #ab87d6;
-	--purple-2: #8d69b5;
-	--cyan: #74c7ec;
-	--yellow: #f9e2af;
-	--green: #a6e3a1;
-	--green-1: #87c282;
-	--green-2: #68a364;
+	--pink: #ed8796;
+	--pink-1: #cb6878;
+	--pink-2: #a94a5b;
+	--purple: #c6a0f6;
+	--purple-1: #a781d4;
+	--purple-2: #8863b4;
+	--cyan: #7dc4e4;
+	--yellow: #eed49f;
+	--green: #a6da95;
+	--green-1: #87ba76;
+	--green-2: #699a58;
 	--lavender: #b4befe;
-	--lavender-1: #a6afe9;
-	--lavender-2: #9aa3e0;
+	--lavender-1: #959edc;
+	--lavender-2: #7780bc;
 }


### PR DESCRIPTION
### catppuccin macchiato lavender

based on the macchiato palette of [catppuccin](https://catppuccin.com/palette) with lavender accents. Changed the corner text to differentiate between mocha and macchiato flavors, though I haven't done this for mocha as I don't know if it's a change worth making.

![Screenshot 2024-09-09 170628](https://github.com/user-attachments/assets/608e0de7-989b-4ba1-82f7-1add6e0bcc85)
