### PR TITLE
Resolves #27 and Fixes "ReadAllNotifications" button cutoff

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -240,6 +240,11 @@ svg[class^=slider_] > rect[fill='white'] /* settings checkbuttons slider */ {
 	}
 }
 
+/*"ReadAllNotifications" button*/
+.vc-ranb-button {
+	font-size: 12px;
+}
+
 /* move chat bar out */
 :root {
 	--custom-channel-textarea-text-area-height: 56px;

--- a/src/main.css
+++ b/src/main.css
@@ -506,6 +506,7 @@ svg[class^=slider_] > rect[fill='white'] /* settings checkbuttons slider */ {
 	font-family: var(--font-primary);
 	font-size: 16px;
 	font-weight: 500;
+	white-space: no-wrap;
 }
 
 /* adjust divider/border thickness */


### PR DESCRIPTION
Resizes the 'Read All' button from the [ReadAllNotifications](https://vencord.dev/plugins/ReadAllNotificationsButton) Vencord plugin to fit in the sidebar at default scaling. 
\
\
![image](https://github.com/user-attachments/assets/996ad19a-ce00-421e-986d-819d893b33c9)
_`Before change`_
\
\
\
![image](https://github.com/user-attachments/assets/9f37996d-4f4a-4faa-a0ff-c402bb1296e3)
_`After change`_

