### PR TITLE
Remove `--white` override

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -864,7 +864,6 @@ html.theme-light {
 	--user-profile-header-overflow-background: hsl(225 calc(1 * 6.3%) 12.5% / 0.5);
 	--voice-video-video-tile-background: hsl(233 calc(1 * 9 / 0.3%) 19% / 0.4);
 	--voice-video-video-tile-blur-fallback: hsl(225 calc(1 * 6.3%) 12.5% / 0.48);
-	--white: var(--bg-0);
 	--you-bar-bg: var(--primary-800);
 
 	--elevation-low: none;


### PR DESCRIPTION
I'm not sure why it's there, the only place where I see `--white` being used is in the the `fill` of vc icons (e.g. mute) which it breaks.

Before:
![image](https://github.com/user-attachments/assets/d286d36d-3910-4952-93dc-2facb6eade78)

After:
![image](https://github.com/user-attachments/assets/008e8ec4-022f-44e3-a508-0a92bb898805)

Edit: I see what it's used for
![image](https://github.com/user-attachments/assets/7344379d-a612-48fa-aea0-133ba92a0e19)

Edit: Similar issue, `--white-500` is used for the open in browser link making it illegible
![image](https://github.com/user-attachments/assets/0af639f0-cbad-4f47-9d28-977005a2d70f)