### PR TITLE
Fix no members text in threads

### DIFF
--- a/src/panel-labels.css
+++ b/src/panel-labels.css
@@ -17,6 +17,7 @@ body {
         .subtitleContainer_f75fb0::after,
         .messagesWrapper__36d07::after,
         .channelTextArea_f75fb0::after,
+        div.membersWrap_c8ffbb::after,
         .container_c8ffbb::after,
         .container__133bf > .container__9293f:after,
         .peopleColumn__133bf::after,
@@ -51,6 +52,7 @@ body {
         .channelTextArea_f75fb0::after {
             content: 'input';
         }
+        div.membersWrap_c8ffbb::after,
         .container_c8ffbb::after {
             content: 'members';
         }
@@ -64,6 +66,7 @@ body {
             content: 'activity';
         }
 
+        .content_f75fb0 > .membersWrap_c8ffbb,
         .panels_c48ade,
         .sidebar_c48ade,
         .sidebarList_c48ade,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/41958199-be99-47bf-9090-121a3a86c443)
I noticed the 'members' text was missing while viewing threads, but they were visible elsewhere.
This PR should resolve this issue.
