### PR TITLE
Fixed input padding and voice channel chat layout

### DIFF
--- a/build/system24.css
+++ b/build/system24.css
@@ -12,6 +12,14 @@ body {
     .bg__960e4 {
         background: var(--bg-base-primary);
     }
+    .container__01ae2 {
+        padding-left: 0 !important;
+        background-color: var(--bg-base-primary);
+    }
+    .form_f75fb0 {
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+    }
 }
 
 /* ascii.css */

--- a/build/system24.css
+++ b/build/system24.css
@@ -16,10 +16,6 @@ body {
         padding-left: 0 !important;
         background-color: var(--bg-base-primary);
     }
-    .form_f75fb0 {
-        padding-left: 0 !important;
-        padding-right: 0 !important;
-    }
 }
 
 /* ascii.css */

--- a/src/main.css
+++ b/src/main.css
@@ -15,8 +15,4 @@ body {
         padding-left: 0 !important;
         background-color: var(--bg-base-primary);
     }
-    .form_f75fb0 {
-        padding-left: 0 !important;
-        padding-right: 0 !important;
-    }
 }

--- a/src/main.css
+++ b/src/main.css
@@ -11,4 +11,12 @@ body {
     .bg__960e4 {
         background: var(--bg-base-primary);
     }
+    .container__01ae2 {
+        padding-left: 0 !important;
+        background-color: var(--bg-base-primary);
+    }
+    .form_f75fb0 {
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+    }
 }


### PR DESCRIPTION
Input field was moved a bit to the right because of padding-left and padding-right and it looked wrong.
Voice chat layout on lower aspect ratio was looking weird because it turned into floating and it looked weird because all 3 parts were separate.

I removed padding from input, removed vc chat left padding and gave it background so it looks more integrated.

Before:
https://domitori.xyz/X7Swt.png

After:
https://domitori.xyz/x0Fp1.png

Couldnt upload images for some reason, sorry for links