### PR TITLE
fix user panel/input panel height inconsistency

### DIFF
--- a/build/system24.css
+++ b/build/system24.css
@@ -161,6 +161,10 @@ body {
     --chatbar-height: 56px !important; /* height of the chatbar (52px by default, 47px recommended for aligned, 56px recommended for separated) */
 }
 
+.avatarWrapper__37e49 {
+    margin: 2px 0 2px 2px !important;
+}
+
 .visual-refresh {
     .bg__960e4 {
         background: var(--bg-base-primary);

--- a/src/main.css
+++ b/src/main.css
@@ -160,6 +160,10 @@ body {
     --chatbar-height: 56px !important; /* height of the chatbar (52px by default, 47px recommended for aligned, 56px recommended for separated) */
 }
 
+.avatarWrapper__37e49 {
+    margin: 2px 0 2px 2px !important;
+}
+
 .visual-refresh {
     .bg__960e4 {
         background: var(--bg-base-primary);


### PR DESCRIPTION
with default settings, the heights of the user panel and the input panel are offset by four pixels. this pr makes them level by adding a small margin to the avatar container. this issue exists whether or not panel labels are on, so i placed the code in the main css file. i can make any other adjustments if needed

**before:**
![CleanShot 2025-06-19 at 22 21 03@2x](https://github.com/user-attachments/assets/0b58638d-0751-45e0-9158-11198f910575)

**after:**
![CleanShot 2025-06-19 at 22 19 42@2x](https://github.com/user-attachments/assets/c498f27e-5312-4672-b867-e30a7d6a0c7c)