### PR TITLE
Feature: Add option to change the casing of panel labels

### DIFF
--- a/build/system24.css
+++ b/build/system24.css
@@ -75,6 +75,7 @@ body {
     --panel-labels: on; /* off: default, on: add labels to panels */
     --label-color: var(--text-muted); /* color of labels */
     --label-font-weight: 500; /* font weight of labels */
+    --label-casing: lowercase; /* lowercase: default, uppercase: make panel labels fully uppercase, capitalize: make panel labels start with a capital letter */
 }
 
 /* color options */
@@ -309,6 +310,7 @@ body {
                 z-index: 100;
                 font-size: 16px;
                 transition: color var(--border-hover-transition);
+                text-transform: var(--label-casing);
             }
 
             &:hover::after {

--- a/src/main.css
+++ b/src/main.css
@@ -74,6 +74,7 @@ body {
     --panel-labels: on; /* off: default, on: add labels to panels */
     --label-color: var(--text-muted); /* color of labels */
     --label-font-weight: 500; /* font weight of labels */
+    --label-casing: lowercase; /* lowercase: default, uppercase: make panel labels fully uppercase, capitalize: make panel labels start with a capital letter */
 }
 
 /* color options */

--- a/src/panel-labels.css
+++ b/src/panel-labels.css
@@ -37,6 +37,7 @@ body {
                 z-index: 100;
                 font-size: 16px;
                 transition: color var(--border-hover-transition);
+                text-transform: var(--label-casing);
             }
 
             &:hover::after {


### PR DESCRIPTION
A tiny addition but can make a world of a difference for the panel labels

### Lowercase (Default)
<img width="228" height="48" alt="Lowercase panel labels" src="https://github.com/user-attachments/assets/7d41724c-ab1b-4a94-bbab-4b31c888f5b5" />

### Capitalize
<img width="228" height="48" alt="Capitalized panel labels" src="https://github.com/user-attachments/assets/294b52ea-634a-483a-b933-c21b33f7d11a" />

### Uppercase
<img width="226" height="54" alt="Uppercase panel labels" src="https://github.com/user-attachments/assets/67501662-ba1d-4130-ba4f-a6989a3e9f11" />
