### PR TITLE
FIX: Slider notch unrounding not working due to class reroll

### DIFF
--- a/src/unrounding.css
+++ b/src/unrounding.css
@@ -76,7 +76,7 @@
         overflow: visible !important;
     }
 
-    .slider__87bf1 > rect[rx='10'] {
+    .slider__6f89e > rect[rx='10'] {
         rx: 0 !important;
     }
 


### PR DESCRIPTION
## Before
<img width="494" height="139" alt="Before" src="https://github.com/user-attachments/assets/8992dc19-bca0-4145-ab99-13302d786091" />

## After
<img width="494" height="139" alt="After" src="https://github.com/user-attachments/assets/3f6c40e3-abd4-43d4-ace0-46b21ff91c48" />
