### PR TITLE
Decouple profile picture rounding from global unrounding

### DIFF
--- a/build/system24.css
+++ b/build/system24.css
@@ -67,6 +67,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */
@@ -213,6 +215,7 @@ body {
         line-height: 1.2;
         background: linear-gradient(to right, var(--brand-360) 0%, var(--background-accent) 25%, var(--background-accent) 75%, var(--brand-360) 100%);
         -webkit-background-clip: text;
+        background-clip: text;
         -webkit-text-fill-color: transparent;
         background-size: 200% auto;
         animation: textShine 1.5s linear infinite reverse;
@@ -495,6 +498,18 @@ body {
     initial-value: on;
 }
 
+@property --round-pfp {
+    syntax: 'off | on';
+    inherits: false;
+    initial-value: off;
+}
+
+@property --remove-pfp-decor {
+    syntax: 'off | on';
+    inherits: false;
+    initial-value: off;
+}
+
 @container body style(--unrounding: on) {
     *,
     *::before,
@@ -508,15 +523,6 @@ body {
         --radius-xl: 0px !important;
         --radius-xxl: 0px !important;
         --radius-round: 0px !important;
-    }
-
-    .svg_cc5dd2 > mask,
-    .svg__44b0c > rect,
-    .svg__44b0c > circle,
-    .svg__44b0c > g,
-    .svg__44b0c rect[mask='url(#:rhi:)'],
-    .avatar__20a53 .status_a423bd {
-        display: none;
     }
 
     .mask__68edb > foreignObject,
@@ -601,6 +607,16 @@ body {
         mask: none;
     }
 
+    /* Remove the banner cutout since it only fits rounded avatars. */
+    .banner_b83360 > div {
+        --custom-cutout-radius: 0px !important;
+    }
+
+    /* subtle avatar shadow for contrast. */
+    .wrapper__44b0c {
+        box-shadow: 0 0 6px rgba(0, 0, 0, 0.9) !important;
+    }
+
     /* equicord switches */
     .vc-switch-indicator .vc-switch-thumb rect {
         rx: var(--radius-lg) !important;
@@ -617,7 +633,7 @@ body {
     /* sticker panel */
     .assetWrapper__31fc2.assetWrapperMasked__31fc2,
     .inspectedIndicator_c6367b {
-        webkit-mask: none;
+        -webkit-mask: none;
         mask: none;
     }
 
@@ -640,6 +656,71 @@ body {
         background-color: var(--checkbox-background-selected-default);
         background-size: 8px 8px;
         border-color: var(--checkbox-border-selected-default);
+    }
+}
+
+@container body style(--round-pfp: off) {
+    .wrapper__44b0c foreignObject {
+        /* Remove Discord's avatar mask to allow square avatars. */
+        mask: none;
+    }
+
+    /* Replace Discord's rounded status indicator with the square variant. */
+    .svg_cc5dd2 > mask,
+    .svg__44b0c > rect,
+    .svg__44b0c > circle,
+    .svg__44b0c > g,
+    .svg__44b0c rect[mask='url(#:rhi:)'],
+    .avatar__20a53 .status_a423bd {
+        display: none;
+    }
+}
+
+@container body style(--round-pfp: on) {
+    /* Restore Discord's default rounded profile avatars. */
+    .wrapper__44b0c,
+    .avatarStack__44b0c,
+    .avatar_c19a55,
+    .avatar__44b0c {
+        border-radius: 50% !important;
+
+        --radius-none: revert !important;
+        --radius-xs: revert !important;
+        --radius-sm: revert !important;
+        --radius-md: revert !important;
+        --radius-lg: revert !important;
+        --radius-xl: revert !important;
+        --radius-xxl: revert !important;
+        --radius-round: revert !important;
+    }
+
+    /* Restore rounded avatars in facepiles and other SVG-based avatars. */
+    foreignObject > img,
+    .circularImage__1ce5d {
+        border-radius: 50% !important;
+    }
+
+    /* Restore Discord's avatar mask. */
+    .wrapper__44b0c foreignObject {
+        mask: url(#svg-mask-avatar-status-round-80) !important;
+    }
+
+    /* Restore Discord's native status indicator. */
+    .container__1ce5d:has(.status_a423bd)::after,
+    .wrapper__44b0c:has(rect)::after {
+        content: none !important;
+    }
+
+    /* Show Discord's original SVG status icon again. */
+    .svg__44b0c > rect {
+        display: initial !important;
+    }
+}
+
+@container body style(--remove-pfp-decor: on) and style(--round-pfp: off) {
+    /* Hide avatar decorations to avoid rounded overlays on square profile pictures. */
+    .avatarDecorationContainer__44b0c {
+        display: none !important;
     }
 }
 

--- a/build/system24.css
+++ b/build/system24.css
@@ -168,6 +168,10 @@ body {
 .bg__960e4 {
     background: var(--background-base-low);
 }
+/* Add contrast to platform icons since the icons have transparent backgrounds */
+.platformIconContainer__9bfb9 {
+    background: rgb(from var(--background-base-low) calc(255 - r) calc(255 - g) calc(255 - b));
+}
 .container__01ae2 {
     background-color: var(--background-base-low);
 }
@@ -513,7 +517,9 @@ body {
 @container body style(--unrounding: on) {
     *,
     *::before,
-    *::after {
+    *::after,
+    /* Exclude avatar wrapper so that --round-pfp has full control */
+    :not(.wrapper__44b0c) {
         border-radius: 0 !important;
         --radius-none: 0px !important;
         --radius-xs: 0px !important;
@@ -526,7 +532,6 @@ body {
     }
 
     .mask__68edb > foreignObject,
-    .svg__44b0c > foreignObject,
     .svg__2338f > foreignObject {
         mask: none;
     }
@@ -602,21 +607,6 @@ body {
         width: 12px !important;
     }
 
-    /* prevent the status circle background mask from blocking avatar decorations in profile popouts */
-    .wrapper__44b0c foreignObject {
-        mask: none;
-    }
-
-    /* Remove the banner cutout since it only fits rounded avatars. */
-    .banner_b83360 > div {
-        --custom-cutout-radius: 0px !important;
-    }
-
-    /* subtle avatar shadow for contrast. */
-    .wrapper__44b0c {
-        box-shadow: 0 0 6px rgba(0, 0, 0, 0.9) !important;
-    }
-
     /* equicord switches */
     .vc-switch-indicator .vc-switch-thumb rect {
         rx: var(--radius-lg) !important;
@@ -659,11 +649,23 @@ body {
     }
 }
 
-/* Active only when unrounding is enabled */
+/* Active only when unrounding is enabled. */
 @container body style(--round-pfp: off) and style(--unrounding: on) {
-    .wrapper__44b0c foreignObject {
-        /* Remove Discord's avatar mask to allow square avatars. */
-        mask: none;
+    /* Remove avatar masks to allow square profile pictures. */
+    .wrapper__44b0c foreignObject,
+    /* Moved here so the avatar mask is only removed for square profile pictures. */
+    .svg__44b0c > foreignObject {
+        mask: none !important;
+    }
+
+    /* Remove the banner cutout since it only fits rounded avatars. */
+    .banner_b83360 > div {
+        --custom-cutout-radius: 0px !important;
+    }
+
+    /* Only apply the avatar shadow when using square profile pictures. */
+    .wrapper__44b0c {
+        box-shadow: 0 0 6px rgba(0, 0, 0, 0.9) !important;
     }
 
     /* Replace Discord's rounded status indicator with the square variant. */
@@ -701,26 +703,17 @@ body {
         border-radius: 50% !important;
     }
 
-    /* Restore Discord's avatar mask. */
-    .wrapper__44b0c foreignObject {
-        mask: url(#svg-mask-avatar-status-round-80) !important;
-    }
-
     /* Restore Discord's native status indicator. */
     .container__1ce5d:has(.status_a423bd)::after,
     .wrapper__44b0c:has(rect)::after {
         content: none !important;
     }
-
-    /* Show Discord's original SVG status icon again. */
-    .svg__44b0c > rect {
-        display: initial !important;
-    }
 }
 
 @container body style(--remove-pfp-decor: on) {
     /* Hide avatar decorations to avoid rounded overlays on square profile pictures. */
-    .avatarDecorationContainer__44b0c {
+    [class*='avatarDecorationContainer__'],
+    [class*='avatarDecoration_'] {
         display: none !important;
     }
 }

--- a/build/system24.css
+++ b/build/system24.css
@@ -168,10 +168,6 @@ body {
 .bg__960e4 {
     background: var(--background-base-low);
 }
-/* Add contrast to platform icons since the icons have transparent backgrounds */
-.platformIconContainer__9bfb9 {
-    background: rgb(from var(--background-base-low) calc(255 - r) calc(255 - g) calc(255 - b));
-}
 .container__01ae2 {
     background-color: var(--background-base-low);
 }
@@ -656,7 +652,7 @@ body {
 /* Active only when unrounding is enabled. */
 @container body style(--round-pfp: off) and style(--unrounding: on) {
     /* Remove avatar masks to allow square profile pictures. */
-    .wrapper__44b0c foreignObject,
+    .wrapper__44b0c > svg > foreignObject,
     /* Moved here so the avatar mask is only removed for square profile pictures. */
     .svg__44b0c > foreignObject,
     .svg__2338f > foreignObject {
@@ -671,14 +667,13 @@ body {
 
     /* Remove the banner cutout since it only fits rounded avatars. */
     /* Discord may change the generated class suffix after updates, hence using ^ (starts with) to match banner classes. */
-    [class^='banner_'] > div {
+    .banner_f7e69e > .banner__68edb {
         --custom-cutout-radius: 0px !important;
     }
 
     /* Only apply the avatar shadow when using square profile pictures. */
     .wrapper__44b0c {
         border-radius: 0 !important;
-        box-shadow: 0 0 6px rgba(0, 0, 0, 0.9) !important;
     }
 
     /* Replace Discord's rounded status indicator with the square variant. */

--- a/build/system24.css
+++ b/build/system24.css
@@ -515,11 +515,10 @@ body {
 }
 
 @container body style(--unrounding: on) {
-    *,
     *::before,
     *::after,
     /* Exclude avatar wrapper so that --round-pfp has full control */
-    :not(.wrapper__44b0c) {
+ *:not(.wrapper__44b0c):not(.container__1ce5d):not(.avatar_c19a55) {
         border-radius: 0 !important;
         --radius-none: 0px !important;
         --radius-xs: 0px !important;
@@ -531,8 +530,12 @@ body {
         --radius-round: 0px !important;
     }
 
-    .mask__68edb > foreignObject,
-    .svg__2338f > foreignObject {
+    /* Server icons */
+    .svg_cc5dd2 > mask {
+        display: none;
+    }
+
+    .mask__68edb > foreignObject {
         mask: none;
     }
 
@@ -654,7 +657,8 @@ body {
     /* Remove avatar masks to allow square profile pictures. */
     .wrapper__44b0c foreignObject,
     /* Moved here so the avatar mask is only removed for square profile pictures. */
-    .svg__44b0c > foreignObject {
+    .svg__44b0c > foreignObject,
+    .svg__2338f > foreignObject {
         mask: none !important;
     }
 
@@ -669,7 +673,6 @@ body {
     }
 
     /* Replace Discord's rounded status indicator with the square variant. */
-    .svg_cc5dd2 > mask,
     .svg__44b0c > rect,
     .svg__44b0c > circle,
     .svg__44b0c > g,
@@ -684,21 +687,7 @@ body {
     .wrapper__44b0c,
     .avatarStack__44b0c,
     .avatar_c19a55,
-    .avatar__44b0c {
-        border-radius: 50% !important;
-
-        --radius-none: revert !important;
-        --radius-xs: revert !important;
-        --radius-sm: revert !important;
-        --radius-md: revert !important;
-        --radius-lg: revert !important;
-        --radius-xl: revert !important;
-        --radius-xxl: revert !important;
-        --radius-round: revert !important;
-    }
-
-    /* Restore rounded avatars in facepiles and other SVG-based avatars. */
-    foreignObject > img,
+    .avatar__44b0c,
     .circularImage__1ce5d {
         border-radius: 50% !important;
     }

--- a/build/system24.css
+++ b/build/system24.css
@@ -68,7 +68,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */
@@ -659,7 +659,8 @@ body {
     }
 }
 
-@container body style(--round-pfp: off) {
+/* Active only when unrounding is enabled */
+@container body style(--round-pfp: off) and style(--unrounding: on) {
     .wrapper__44b0c foreignObject {
         /* Remove Discord's avatar mask to allow square avatars. */
         mask: none;
@@ -676,7 +677,7 @@ body {
     }
 }
 
-@container body style(--round-pfp: on) {
+@container body style(--round-pfp: on) and style(--unrounding: on) {
     /* Restore Discord's default rounded profile avatars. */
     .wrapper__44b0c,
     .avatarStack__44b0c,
@@ -717,7 +718,7 @@ body {
     }
 }
 
-@container body style(--remove-pfp-decor: on) and style(--round-pfp: off) {
+@container body style(--remove-pfp-decor: on) {
     /* Hide avatar decorations to avoid rounded overlays on square profile pictures. */
     .avatarDecorationContainer__44b0c {
         display: none !important;

--- a/build/system24.css
+++ b/build/system24.css
@@ -514,7 +514,7 @@ body {
     *::before,
     *::after,
     /* Exclude avatar wrapper so that --round-pfp has full control */
- *:not(.wrapper__44b0c):not(.container__1ce5d):not(.avatar_c19a55):not(.replyAvatar_c19a55) {
+    *:not(.wrapper__44b0c):not(.avatar_c19a55):not(.replyAvatar_c19a55) {
         border-radius: 0 !important;
         --radius-none: 0px !important;
         --radius-xs: 0px !important;
@@ -666,12 +666,10 @@ body {
     }
 
     /* Remove the banner cutout since it only fits rounded avatars. */
-    /* Discord may change the generated class suffix after updates, hence using ^ (starts with) to match banner classes. */
     .banner_f7e69e > .banner__68edb {
         --custom-cutout-radius: 0px !important;
     }
 
-    /* Only apply the avatar shadow when using square profile pictures. */
     .wrapper__44b0c {
         border-radius: 0 !important;
     }
@@ -687,16 +685,6 @@ body {
 }
 
 @container body style(--round-pfp: on) and style(--unrounding: on) {
-    /* Restore Discord's default rounded profile avatars. */
-    .wrapper__44b0c,
-    .avatarStack__44b0c,
-    .avatar_c19a55,
-    .avatar__44b0c,
-    .replyAvatar_c19a55,
-    .circularImage__1ce5d {
-        border-radius: 50% !important;
-    }
-
     /* Restore Discord's native status indicator. */
     .wrapper__44b0c::after,
     .container__1ce5d::after {
@@ -707,8 +695,8 @@ body {
 
 @container body style(--remove-pfp-decor: on) {
     /* Hide avatar decorations to avoid rounded overlays on square profile pictures. */
-    [class^='avatarDecorationContainer__'],
-    [class^='avatarDecoration_'] {
+    .avatarDecorationContainer__44b0c,
+    .avatarDecoration__44b0c {
         display: none !important;
     }
 }

--- a/build/system24.css
+++ b/build/system24.css
@@ -518,7 +518,7 @@ body {
     *::before,
     *::after,
     /* Exclude avatar wrapper so that --round-pfp has full control */
- *:not(.wrapper__44b0c):not(.container__1ce5d):not(.avatar_c19a55) {
+ *:not(.wrapper__44b0c):not(.container__1ce5d):not(.avatar_c19a55):not(.replyAvatar_c19a55) {
         border-radius: 0 !important;
         --radius-none: 0px !important;
         --radius-xs: 0px !important;
@@ -535,7 +535,8 @@ body {
         display: none;
     }
 
-    .mask__68edb > foreignObject {
+    .mask__68edb > foreignObject,
+    .svg__2338f.imageContainer_ef9ae7 > foreignObject {
         mask: none;
     }
 
@@ -662,6 +663,11 @@ body {
         mask: none !important;
     }
 
+    .avatar_c19a55,
+    .replyAvatar_c19a55 {
+        border-radius: 0 !important;
+    }
+
     /* Remove the banner cutout since it only fits rounded avatars. */
     .banner_b83360 > div {
         --custom-cutout-radius: 0px !important;
@@ -669,6 +675,7 @@ body {
 
     /* Only apply the avatar shadow when using square profile pictures. */
     .wrapper__44b0c {
+        border-radius: 0 !important;
         box-shadow: 0 0 6px rgba(0, 0, 0, 0.9) !important;
     }
 
@@ -688,6 +695,7 @@ body {
     .avatarStack__44b0c,
     .avatar_c19a55,
     .avatar__44b0c,
+    .replyAvatar_c19a55,
     .circularImage__1ce5d {
         border-radius: 50% !important;
     }

--- a/build/system24.css
+++ b/build/system24.css
@@ -663,13 +663,15 @@ body {
         mask: none !important;
     }
 
+    /* Remove the border radius from reply avatars. */
     .avatar_c19a55,
     .replyAvatar_c19a55 {
         border-radius: 0 !important;
     }
 
     /* Remove the banner cutout since it only fits rounded avatars. */
-    .banner_b83360 > div {
+    /* Discord may change the generated class suffix after updates, hence using ^ (starts with) to match banner classes. */
+    [class^='banner_'] > div {
         --custom-cutout-radius: 0px !important;
     }
 
@@ -701,16 +703,17 @@ body {
     }
 
     /* Restore Discord's native status indicator. */
-    .container__1ce5d:has(.status_a423bd)::after,
-    .wrapper__44b0c:has(rect)::after {
+    .wrapper__44b0c::after,
+    .container__1ce5d::after {
         content: none !important;
+        display: none !important;
     }
 }
 
 @container body style(--remove-pfp-decor: on) {
     /* Hide avatar decorations to avoid rounded overlays on square profile pictures. */
-    [class*='avatarDecorationContainer__'],
-    [class*='avatarDecoration_'] {
+    [class^='avatarDecorationContainer__'],
+    [class^='avatarDecoration_'] {
         display: none !important;
     }
 }

--- a/build/system24.css
+++ b/build/system24.css
@@ -514,7 +514,7 @@ body {
     *::before,
     *::after,
     /* Exclude avatar wrapper so that --round-pfp has full control */
-    *:not(.wrapper__44b0c):not(.avatar_c19a55):not(.replyAvatar_c19a55) {
+ *:not(.wrapper__44b0c):not(.container__1ce5d):not(.avatar_c19a55):not(.replyAvatar_c19a55) {
         border-radius: 0 !important;
         --radius-none: 0px !important;
         --radius-xs: 0px !important;
@@ -544,7 +544,7 @@ body {
         --offline-2: #82838b;
         --streaming-2: #9147ff;
     }
-    .wrapper__44b0c:has(> .svg__44b0c rect)::after,
+    .wrapper__44b0c:has(> .svg__44b0c > g > rect)::after,
     .container__1ce5d:has(> .mask_a423bd .status_a423bd)::after {
         content: '';
         display: block;
@@ -673,6 +673,9 @@ body {
     .wrapper__44b0c {
         border-radius: 0 !important;
     }
+    .avatar__75742 .wrapper__44b0c {
+        border: 2px solid var(--background-base-lower);
+    }
 
     /* Replace Discord's rounded status indicator with the square variant. */
     .svg__44b0c > rect,
@@ -695,7 +698,7 @@ body {
 
 @container body style(--remove-pfp-decor: on) {
     /* Hide avatar decorations to avoid rounded overlays on square profile pictures. */
-    .avatarDecorationContainer__44b0c,
+    .avatarDecoration_c19a55,
     .avatarDecoration__44b0c {
         display: none !important;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "systemtheme",
-	"version": "1.0.0",
+	"version": "2.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "systemtheme",
-			"version": "1.0.0",
+			"version": "2.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"chokidar": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "systemtheme",
-	"version": "1.0.0",
+	"version": "2.1.0",
 	"scripts": {
 		"build": "node scripts/build.js",
 		"dev": "node scripts/dev.js",

--- a/src/ascii.css
+++ b/src/ascii.css
@@ -37,6 +37,7 @@
         line-height: 1.2;
         background: linear-gradient(to right, var(--brand-360) 0%, var(--background-accent) 25%, var(--background-accent) 75%, var(--brand-360) 100%);
         -webkit-background-clip: text;
+        background-clip: text;
         -webkit-text-fill-color: transparent;
         background-size: 200% auto;
         animation: textShine 1.5s linear infinite reverse;

--- a/src/main.css
+++ b/src/main.css
@@ -167,6 +167,10 @@ body {
 .bg__960e4 {
     background: var(--background-base-low);
 }
+/* Add contrast to platform icons since the icons have transparent backgrounds */
+.platformIconContainer__9bfb9 {
+    background: rgb(from var(--background-base-low) calc(255 - r) calc(255 - g) calc(255 - b));
+}
 .container__01ae2 {
     background-color: var(--background-base-low);
 }

--- a/src/main.css
+++ b/src/main.css
@@ -67,7 +67,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/src/main.css
+++ b/src/main.css
@@ -66,6 +66,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/src/main.css
+++ b/src/main.css
@@ -167,10 +167,6 @@ body {
 .bg__960e4 {
     background: var(--background-base-low);
 }
-/* Add contrast to platform icons since the icons have transparent backgrounds */
-.platformIconContainer__9bfb9 {
-    background: rgb(from var(--background-base-low) calc(255 - r) calc(255 - g) calc(255 - b));
-}
 .container__01ae2 {
     background-color: var(--background-base-low);
 }

--- a/src/unrounding.css
+++ b/src/unrounding.css
@@ -165,7 +165,8 @@
     }
 }
 
-@container body style(--round-pfp: off) {
+/* Active only when unrounding is enabled */
+@container body style(--round-pfp: off) and style(--unrounding: on) {
     .wrapper__44b0c foreignObject {
         /* Remove Discord's avatar mask to allow square avatars. */
         mask: none;
@@ -182,7 +183,7 @@
     }
 }
 
-@container body style(--round-pfp: on) {
+@container body style(--round-pfp: on) and style(--unrounding: on) {
     /* Restore Discord's default rounded profile avatars. */
     .wrapper__44b0c,
     .avatarStack__44b0c,
@@ -223,7 +224,7 @@
     }
 }
 
-@container body style(--remove-pfp-decor: on) and style(--round-pfp: off) {
+@container body style(--remove-pfp-decor: on) {
     /* Hide avatar decorations to avoid rounded overlays on square profile pictures. */
     .avatarDecorationContainer__44b0c {
         display: none !important;

--- a/src/unrounding.css
+++ b/src/unrounding.css
@@ -19,7 +19,9 @@
 @container body style(--unrounding: on) {
     *,
     *::before,
-    *::after {
+    *::after,
+    /* Exclude avatar wrapper so that --round-pfp has full control */
+    :not(.wrapper__44b0c) {
         border-radius: 0 !important;
         --radius-none: 0px !important;
         --radius-xs: 0px !important;
@@ -32,7 +34,6 @@
     }
 
     .mask__68edb > foreignObject,
-    .svg__44b0c > foreignObject,
     .svg__2338f > foreignObject {
         mask: none;
     }
@@ -108,21 +109,6 @@
         width: 12px !important;
     }
 
-    /* prevent the status circle background mask from blocking avatar decorations in profile popouts */
-    .wrapper__44b0c foreignObject {
-        mask: none;
-    }
-
-    /* Remove the banner cutout since it only fits rounded avatars. */
-    .banner_b83360 > div {
-        --custom-cutout-radius: 0px !important;
-    }
-
-    /* subtle avatar shadow for contrast. */
-    .wrapper__44b0c {
-        box-shadow: 0 0 6px rgba(0, 0, 0, 0.9) !important;
-    }
-
     /* equicord switches */
     .vc-switch-indicator .vc-switch-thumb rect {
         rx: var(--radius-lg) !important;
@@ -165,11 +151,23 @@
     }
 }
 
-/* Active only when unrounding is enabled */
+/* Active only when unrounding is enabled. */
 @container body style(--round-pfp: off) and style(--unrounding: on) {
-    .wrapper__44b0c foreignObject {
-        /* Remove Discord's avatar mask to allow square avatars. */
-        mask: none;
+    /* Remove avatar masks to allow square profile pictures. */
+    .wrapper__44b0c foreignObject,
+    /* Moved here so the avatar mask is only removed for square profile pictures. */
+    .svg__44b0c > foreignObject {
+        mask: none !important;
+    }
+
+    /* Remove the banner cutout since it only fits rounded avatars. */
+    .banner_b83360 > div {
+        --custom-cutout-radius: 0px !important;
+    }
+
+    /* Only apply the avatar shadow when using square profile pictures. */
+    .wrapper__44b0c {
+        box-shadow: 0 0 6px rgba(0, 0, 0, 0.9) !important;
     }
 
     /* Replace Discord's rounded status indicator with the square variant. */
@@ -207,20 +205,10 @@
         border-radius: 50% !important;
     }
 
-    /* Restore Discord's avatar mask. */
-    .wrapper__44b0c foreignObject {
-        mask: url(#svg-mask-avatar-status-round-80) !important;
-    }
-
     /* Restore Discord's native status indicator. */
     .container__1ce5d:has(.status_a423bd)::after,
     .wrapper__44b0c:has(rect)::after {
         content: none !important;
-    }
-
-    /* Show Discord's original SVG status icon again. */
-    .svg__44b0c > rect {
-        display: initial !important;
     }
 }
 

--- a/src/unrounding.css
+++ b/src/unrounding.css
@@ -201,7 +201,7 @@
 
 @container body style(--remove-pfp-decor: on) {
     /* Hide avatar decorations to avoid rounded overlays on square profile pictures. */
-    .avatarDecorationContainer__44b0c,
+    .avatarDecoration_c19a55,
     .avatarDecoration__44b0c {
         display: none !important;
     }

--- a/src/unrounding.css
+++ b/src/unrounding.css
@@ -4,6 +4,18 @@
     initial-value: on;
 }
 
+@property --round-pfp {
+    syntax: 'off | on';
+    inherits: false;
+    initial-value: off;
+}
+
+@property --remove-pfp-decor {
+    syntax: 'off | on';
+    inherits: false;
+    initial-value: off;
+}
+
 @container body style(--unrounding: on) {
     *,
     *::before,
@@ -17,15 +29,6 @@
         --radius-xl: 0px !important;
         --radius-xxl: 0px !important;
         --radius-round: 0px !important;
-    }
-
-    .svg_cc5dd2 > mask,
-    .svg__44b0c > rect,
-    .svg__44b0c > circle,
-    .svg__44b0c > g,
-    .svg__44b0c rect[mask='url(#:rhi:)'],
-    .avatar__20a53 .status_a423bd {
-        display: none;
     }
 
     .mask__68edb > foreignObject,
@@ -110,6 +113,16 @@
         mask: none;
     }
 
+    /* Remove the banner cutout since it only fits rounded avatars. */
+    .banner_b83360 > div {
+        --custom-cutout-radius: 0px !important;
+    }
+
+    /* subtle avatar shadow for contrast. */
+    .wrapper__44b0c {
+        box-shadow: 0 0 6px rgba(0, 0, 0, 0.9) !important;
+    }
+
     /* equicord switches */
     .vc-switch-indicator .vc-switch-thumb rect {
         rx: var(--radius-lg) !important;
@@ -126,7 +139,7 @@
     /* sticker panel */
     .assetWrapper__31fc2.assetWrapperMasked__31fc2,
     .inspectedIndicator_c6367b {
-        webkit-mask: none;
+        -webkit-mask: none;
         mask: none;
     }
 
@@ -149,5 +162,70 @@
         background-color: var(--checkbox-background-selected-default);
         background-size: 8px 8px;
         border-color: var(--checkbox-border-selected-default);
+    }
+}
+
+@container body style(--round-pfp: off) {
+    .wrapper__44b0c foreignObject {
+        /* Remove Discord's avatar mask to allow square avatars. */
+        mask: none;
+    }
+
+    /* Replace Discord's rounded status indicator with the square variant. */
+    .svg_cc5dd2 > mask,
+    .svg__44b0c > rect,
+    .svg__44b0c > circle,
+    .svg__44b0c > g,
+    .svg__44b0c rect[mask='url(#:rhi:)'],
+    .avatar__20a53 .status_a423bd {
+        display: none;
+    }
+}
+
+@container body style(--round-pfp: on) {
+    /* Restore Discord's default rounded profile avatars. */
+    .wrapper__44b0c,
+    .avatarStack__44b0c,
+    .avatar_c19a55,
+    .avatar__44b0c {
+        border-radius: 50% !important;
+
+        --radius-none: revert !important;
+        --radius-xs: revert !important;
+        --radius-sm: revert !important;
+        --radius-md: revert !important;
+        --radius-lg: revert !important;
+        --radius-xl: revert !important;
+        --radius-xxl: revert !important;
+        --radius-round: revert !important;
+    }
+
+    /* Restore rounded avatars in facepiles and other SVG-based avatars. */
+    foreignObject > img,
+    .circularImage__1ce5d {
+        border-radius: 50% !important;
+    }
+
+    /* Restore Discord's avatar mask. */
+    .wrapper__44b0c foreignObject {
+        mask: url(#svg-mask-avatar-status-round-80) !important;
+    }
+
+    /* Restore Discord's native status indicator. */
+    .container__1ce5d:has(.status_a423bd)::after,
+    .wrapper__44b0c:has(rect)::after {
+        content: none !important;
+    }
+
+    /* Show Discord's original SVG status icon again. */
+    .svg__44b0c > rect {
+        display: initial !important;
+    }
+}
+
+@container body style(--remove-pfp-decor: on) and style(--round-pfp: off) {
+    /* Hide avatar decorations to avoid rounded overlays on square profile pictures. */
+    .avatarDecorationContainer__44b0c {
+        display: none !important;
     }
 }

--- a/src/unrounding.css
+++ b/src/unrounding.css
@@ -20,7 +20,7 @@
     *::before,
     *::after,
     /* Exclude avatar wrapper so that --round-pfp has full control */
-    *:not(.wrapper__44b0c):not(.avatar_c19a55):not(.replyAvatar_c19a55) {
+ *:not(.wrapper__44b0c):not(.container__1ce5d):not(.avatar_c19a55):not(.replyAvatar_c19a55) {
         border-radius: 0 !important;
         --radius-none: 0px !important;
         --radius-xs: 0px !important;
@@ -50,7 +50,7 @@
         --offline-2: #82838b;
         --streaming-2: #9147ff;
     }
-    .wrapper__44b0c:has(> .svg__44b0c rect)::after,
+    .wrapper__44b0c:has(> .svg__44b0c > g > rect)::after,
     .container__1ce5d:has(> .mask_a423bd .status_a423bd)::after {
         content: '';
         display: block;
@@ -178,6 +178,9 @@
 
     .wrapper__44b0c {
         border-radius: 0 !important;
+    }
+    .avatar__75742 .wrapper__44b0c {
+        border: 2px solid var(--background-base-lower);
     }
 
     /* Replace Discord's rounded status indicator with the square variant. */

--- a/src/unrounding.css
+++ b/src/unrounding.css
@@ -20,7 +20,7 @@
     *::before,
     *::after,
     /* Exclude avatar wrapper so that --round-pfp has full control */
- *:not(.wrapper__44b0c):not(.container__1ce5d):not(.avatar_c19a55):not(.replyAvatar_c19a55) {
+    *:not(.wrapper__44b0c):not(.avatar_c19a55):not(.replyAvatar_c19a55) {
         border-radius: 0 !important;
         --radius-none: 0px !important;
         --radius-xs: 0px !important;
@@ -172,12 +172,10 @@
     }
 
     /* Remove the banner cutout since it only fits rounded avatars. */
-    /* Discord may change the generated class suffix after updates, hence using ^ (starts with) to match banner classes. */
     .banner_f7e69e > .banner__68edb {
         --custom-cutout-radius: 0px !important;
     }
 
-    /* Only apply the avatar shadow when using square profile pictures. */
     .wrapper__44b0c {
         border-radius: 0 !important;
     }
@@ -193,16 +191,6 @@
 }
 
 @container body style(--round-pfp: on) and style(--unrounding: on) {
-    /* Restore Discord's default rounded profile avatars. */
-    .wrapper__44b0c,
-    .avatarStack__44b0c,
-    .avatar_c19a55,
-    .avatar__44b0c,
-    .replyAvatar_c19a55,
-    .circularImage__1ce5d {
-        border-radius: 50% !important;
-    }
-
     /* Restore Discord's native status indicator. */
     .wrapper__44b0c::after,
     .container__1ce5d::after {
@@ -213,8 +201,8 @@
 
 @container body style(--remove-pfp-decor: on) {
     /* Hide avatar decorations to avoid rounded overlays on square profile pictures. */
-    [class^='avatarDecorationContainer__'],
-    [class^='avatarDecoration_'] {
+    .avatarDecorationContainer__44b0c,
+    .avatarDecoration__44b0c {
         display: none !important;
     }
 }

--- a/src/unrounding.css
+++ b/src/unrounding.css
@@ -226,7 +226,8 @@
 
 @container body style(--remove-pfp-decor: on) {
     /* Hide avatar decorations to avoid rounded overlays on square profile pictures. */
-    .avatarDecorationContainer__44b0c {
+    [class*='avatarDecorationContainer__'],
+    [class*='avatarDecoration_'] {
         display: none !important;
     }
 }

--- a/src/unrounding.css
+++ b/src/unrounding.css
@@ -17,11 +17,10 @@
 }
 
 @container body style(--unrounding: on) {
-    *,
     *::before,
     *::after,
     /* Exclude avatar wrapper so that --round-pfp has full control */
-    :not(.wrapper__44b0c) {
+ *:not(.wrapper__44b0c):not(.container__1ce5d):not(.avatar_c19a55) {
         border-radius: 0 !important;
         --radius-none: 0px !important;
         --radius-xs: 0px !important;
@@ -33,8 +32,12 @@
         --radius-round: 0px !important;
     }
 
-    .mask__68edb > foreignObject,
-    .svg__2338f > foreignObject {
+    /* Server icons */
+    .svg_cc5dd2 > mask {
+        display: none;
+    }
+
+    .mask__68edb > foreignObject {
         mask: none;
     }
 
@@ -156,7 +159,8 @@
     /* Remove avatar masks to allow square profile pictures. */
     .wrapper__44b0c foreignObject,
     /* Moved here so the avatar mask is only removed for square profile pictures. */
-    .svg__44b0c > foreignObject {
+    .svg__44b0c > foreignObject,
+    .svg__2338f > foreignObject {
         mask: none !important;
     }
 
@@ -171,7 +175,6 @@
     }
 
     /* Replace Discord's rounded status indicator with the square variant. */
-    .svg_cc5dd2 > mask,
     .svg__44b0c > rect,
     .svg__44b0c > circle,
     .svg__44b0c > g,
@@ -186,21 +189,7 @@
     .wrapper__44b0c,
     .avatarStack__44b0c,
     .avatar_c19a55,
-    .avatar__44b0c {
-        border-radius: 50% !important;
-
-        --radius-none: revert !important;
-        --radius-xs: revert !important;
-        --radius-sm: revert !important;
-        --radius-md: revert !important;
-        --radius-lg: revert !important;
-        --radius-xl: revert !important;
-        --radius-xxl: revert !important;
-        --radius-round: revert !important;
-    }
-
-    /* Restore rounded avatars in facepiles and other SVG-based avatars. */
-    foreignObject > img,
+    .avatar__44b0c,
     .circularImage__1ce5d {
         border-radius: 50% !important;
     }

--- a/src/unrounding.css
+++ b/src/unrounding.css
@@ -158,7 +158,7 @@
 /* Active only when unrounding is enabled. */
 @container body style(--round-pfp: off) and style(--unrounding: on) {
     /* Remove avatar masks to allow square profile pictures. */
-    .wrapper__44b0c foreignObject,
+    .wrapper__44b0c > svg > foreignObject,
     /* Moved here so the avatar mask is only removed for square profile pictures. */
     .svg__44b0c > foreignObject,
     .svg__2338f > foreignObject {
@@ -173,14 +173,13 @@
 
     /* Remove the banner cutout since it only fits rounded avatars. */
     /* Discord may change the generated class suffix after updates, hence using ^ (starts with) to match banner classes. */
-    [class^='banner_'] > div {
+    .banner_f7e69e > .banner__68edb {
         --custom-cutout-radius: 0px !important;
     }
 
     /* Only apply the avatar shadow when using square profile pictures. */
     .wrapper__44b0c {
         border-radius: 0 !important;
-        box-shadow: 0 0 6px rgba(0, 0, 0, 0.9) !important;
     }
 
     /* Replace Discord's rounded status indicator with the square variant. */

--- a/src/unrounding.css
+++ b/src/unrounding.css
@@ -20,7 +20,7 @@
     *::before,
     *::after,
     /* Exclude avatar wrapper so that --round-pfp has full control */
- *:not(.wrapper__44b0c):not(.container__1ce5d):not(.avatar_c19a55) {
+ *:not(.wrapper__44b0c):not(.container__1ce5d):not(.avatar_c19a55):not(.replyAvatar_c19a55) {
         border-radius: 0 !important;
         --radius-none: 0px !important;
         --radius-xs: 0px !important;
@@ -37,7 +37,8 @@
         display: none;
     }
 
-    .mask__68edb > foreignObject {
+    .mask__68edb > foreignObject,
+    .svg__2338f.imageContainer_ef9ae7 > foreignObject {
         mask: none;
     }
 
@@ -164,6 +165,11 @@
         mask: none !important;
     }
 
+    .avatar_c19a55,
+    .replyAvatar_c19a55 {
+        border-radius: 0 !important;
+    }
+
     /* Remove the banner cutout since it only fits rounded avatars. */
     .banner_b83360 > div {
         --custom-cutout-radius: 0px !important;
@@ -171,6 +177,7 @@
 
     /* Only apply the avatar shadow when using square profile pictures. */
     .wrapper__44b0c {
+        border-radius: 0 !important;
         box-shadow: 0 0 6px rgba(0, 0, 0, 0.9) !important;
     }
 
@@ -190,6 +197,7 @@
     .avatarStack__44b0c,
     .avatar_c19a55,
     .avatar__44b0c,
+    .replyAvatar_c19a55,
     .circularImage__1ce5d {
         border-radius: 50% !important;
     }

--- a/src/unrounding.css
+++ b/src/unrounding.css
@@ -165,13 +165,15 @@
         mask: none !important;
     }
 
+    /* Remove the border radius from reply avatars. */
     .avatar_c19a55,
     .replyAvatar_c19a55 {
         border-radius: 0 !important;
     }
 
     /* Remove the banner cutout since it only fits rounded avatars. */
-    .banner_b83360 > div {
+    /* Discord may change the generated class suffix after updates, hence using ^ (starts with) to match banner classes. */
+    [class^='banner_'] > div {
         --custom-cutout-radius: 0px !important;
     }
 
@@ -203,16 +205,17 @@
     }
 
     /* Restore Discord's native status indicator. */
-    .container__1ce5d:has(.status_a423bd)::after,
-    .wrapper__44b0c:has(rect)::after {
+    .wrapper__44b0c::after,
+    .container__1ce5d::after {
         content: none !important;
+        display: none !important;
     }
 }
 
 @container body style(--remove-pfp-decor: on) {
     /* Hide avatar decorations to avoid rounded overlays on square profile pictures. */
-    [class*='avatarDecorationContainer__'],
-    [class*='avatarDecoration_'] {
+    [class^='avatarDecorationContainer__'],
+    [class^='avatarDecoration_'] {
         display: none !important;
     }
 }

--- a/theme/flavors/system24-auto.theme.css
+++ b/theme/flavors/system24-auto.theme.css
@@ -2,7 +2,7 @@
  * @name system24 (auto)
  * @description a tui-style discord theme that follows your system color scheme.
  * @author refact0r
- * @version 2.0.0
+ * @version 2.1.0
  * @invite nz87hXyvcy
  * @website https://github.com/refact0r/system24
  * @source https://github.com/refact0r/system24/blob/master/theme/flavors/system24-auto.theme.css
@@ -69,6 +69,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-auto.theme.css
+++ b/theme/flavors/system24-auto.theme.css
@@ -70,7 +70,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-catppuccin-macchiato.theme.css
+++ b/theme/flavors/system24-catppuccin-macchiato.theme.css
@@ -2,7 +2,7 @@
  * @name system24 (catppuccin macchiato)
  * @description a tui-style discord theme. based on catppuccin macchiato theme (https://catppuccin.com).
  * @author refact0r
- * @version 2.0.0
+ * @version 2.1.0
  * @invite nz87hXyvcy
  * @website https://github.com/refact0r/system24
  * @source https://github.com/refact0r/system24/blob/master/theme/system24-catppuccin-macchiato.theme.css
@@ -69,6 +69,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-catppuccin-macchiato.theme.css
+++ b/theme/flavors/system24-catppuccin-macchiato.theme.css
@@ -70,7 +70,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-catppuccin-mocha.theme.css
+++ b/theme/flavors/system24-catppuccin-mocha.theme.css
@@ -70,7 +70,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-catppuccin-mocha.theme.css
+++ b/theme/flavors/system24-catppuccin-mocha.theme.css
@@ -2,7 +2,7 @@
  * @name system24 (catppuccin mocha)
  * @description a tui-style discord theme. based on catppuccin mocha theme (https://catppuccin.com).
  * @author refact0r
- * @version 2.0.0
+ * @version 2.1.0
  * @invite nz87hXyvcy
  * @website https://github.com/refact0r/system24
  * @source https://github.com/refact0r/system24/blob/master/theme/system24-catppuccin-mocha.theme.css
@@ -69,6 +69,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-everforest.theme.css
+++ b/theme/flavors/system24-everforest.theme.css
@@ -2,7 +2,7 @@
  * @name system24 (everforest)
  * @description a tui-style discord theme.
  * @author refact0r
- * @version 2.0.0
+ * @version 2.1.0
  * @invite nz87hXyvcy
  * @website https://github.com/refact0r/system24
  * @source https://github.com/refact0r/system24/blob/master/theme/system24.theme.css
@@ -69,6 +69,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-everforest.theme.css
+++ b/theme/flavors/system24-everforest.theme.css
@@ -70,7 +70,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-light.theme.css
+++ b/theme/flavors/system24-light.theme.css
@@ -2,7 +2,7 @@
  * @name system24 (light)
  * @description a light, tui-style discord theme.
  * @author refact0r
- * @version 2.0.0
+ * @version 2.1.0
  * @invite nz87hXyvcy
  * @website https://github.com/refact0r/system24
  * @source https://github.com/refact0r/system24/blob/master/theme/flavors/system24-light.theme.css
@@ -69,6 +69,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-light.theme.css
+++ b/theme/flavors/system24-light.theme.css
@@ -70,7 +70,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-nord.theme.css
+++ b/theme/flavors/system24-nord.theme.css
@@ -2,7 +2,7 @@
  * @name system24 (nord)
  * @description a tui-style discord theme. based on nord theme (https://www.nordtheme.com).
  * @author refact0r
- * @version 2.0.0
+ * @version 2.1.0
  * @invite nz87hXyvcy
  * @website https://github.com/refact0r/system24
  * @source https://github.com/refact0r/system24/blob/master/theme/system24-nord.theme.css
@@ -69,6 +69,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-nord.theme.css
+++ b/theme/flavors/system24-nord.theme.css
@@ -70,7 +70,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-rose-pine-moon.theme.css
+++ b/theme/flavors/system24-rose-pine-moon.theme.css
@@ -2,7 +2,7 @@
  * @name system24 (rosé pine moon) 
  * @description a tui-style discord theme. based on rosé pine moon theme (https://rosepinetheme.com).
  * @author refact0r
- * @version 2.0.0
+ * @version 2.1.0
  * @invite nz87hXyvcy
  * @website https://github.com/refact0r/system24
  * @source https://github.com/refact0r/system24/blob/master/theme/system24-rose-pine-moon.theme.css
@@ -69,6 +69,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-rose-pine-moon.theme.css
+++ b/theme/flavors/system24-rose-pine-moon.theme.css
@@ -70,7 +70,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-rose-pine.theme.css
+++ b/theme/flavors/system24-rose-pine.theme.css
@@ -70,7 +70,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-rose-pine.theme.css
+++ b/theme/flavors/system24-rose-pine.theme.css
@@ -2,7 +2,7 @@
  * @name system24 (rosé pine)
  * @description a tui-style discord theme. based on rosé pine theme (https://rosepinetheme.com).
  * @author refact0r
- * @version 2.0.0
+ * @version 2.1.0
  * @invite nz87hXyvcy
  * @website https://github.com/refact0r/system24
  * @source https://github.com/refact0r/system24/blob/master/theme/system24-rose-pine.theme.css
@@ -69,6 +69,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-tokyo-night.theme.css
+++ b/theme/flavors/system24-tokyo-night.theme.css
@@ -2,7 +2,7 @@
  * @name system24 (tokyo night)
  * @description a tui-style discord theme. based on tokyo night theme (https://github.com/tokyo-night/tokyo-night-vscode-theme).
  * @author refact0r
- * @version 2.0.0
+ * @version 2.1.0
  * @invite nz87hXyvcy
  * @website https://github.com/refact0r/system24
  * @source https://github.com/refact0r/system24/blob/master/theme/system24-tokyo-night.theme.css
@@ -69,6 +69,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-tokyo-night.theme.css
+++ b/theme/flavors/system24-tokyo-night.theme.css
@@ -70,7 +70,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-vencord.theme.css
+++ b/theme/flavors/system24-vencord.theme.css
@@ -2,7 +2,7 @@
  * @name system24 (vencord)
  * @description a tui-style discord theme. based on https://github.com/nanoqoi/vencord-theme.
  * @author refact0r
- * @version 2.0.0
+ * @version 2.1.0
  * @invite nz87hXyvcy
  * @website https://github.com/refact0r/system24
  * @source https://github.com/refact0r/system24/blob/master/theme/system24-vencord.theme.css
@@ -69,6 +69,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/flavors/system24-vencord.theme.css
+++ b/theme/flavors/system24-vencord.theme.css
@@ -70,7 +70,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/system24.theme.css
+++ b/theme/system24.theme.css
@@ -69,7 +69,7 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
-    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --round-pfp: on; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
     --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */

--- a/theme/system24.theme.css
+++ b/theme/system24.theme.css
@@ -2,7 +2,7 @@
  * @name system24
  * @description a tui-style discord theme.
  * @author refact0r
- * @version 2.0.0
+ * @version 2.1.0
  * @invite nz87hXyvcy
  * @website https://github.com/refact0r/system24
  * @source https://github.com/refact0r/system24/blob/master/theme/system24.theme.css
@@ -69,6 +69,8 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/system24.theme.css
+++ b/theme/system24.theme.css
@@ -70,7 +70,7 @@ body {
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
     --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
-    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations (only applies if --round-pfp is off) */
+    --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */
     --custom-spotify-bar: on; /* off: default, on: custom text-like spotify progress bar */

--- a/theme/system24.theme.css
+++ b/theme/system24.theme.css
@@ -69,7 +69,7 @@ body {
 
     /* unrounding options */
     --unrounding: on; /* off: default, on: remove rounded corners from panels */
-    --round-pfp: on; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
+    --round-pfp: off; /* off: square profile pictures, on: rounded profile pictures (Discord default) */
     --remove-pfp-decor: off; /* off: default, on: remove profile picture decorations */
 
     /* styling options */


### PR DESCRIPTION
## Summary

This PR separates profile picture rounding from the global unrounding option, allowing users to independently choose whether profile pictures remain square or use Discord's default rounded appearance.

## Changes

- Added a new `--round-pfp` option to control profile picture rounding independently of global unrounding.
- Added a `--remove-pfp-decor` option to hide avatar decorations when using square profile pictures.
- Restored Discord's default avatar masks and status indicators when rounded profile pictures are enabled.
- Applied rounded corners to additional SVG-based profile pictures (e.g. facepile/group icons) for consistent behavior.
- Added a subtle profile picture shadow to improve contrast in profile popouts.
- Improved profile popout appearance by removing the banner avatar cutout when using square profile pictures: <p align="center">
<img width="210" height="84" alt="Untitled design (12)" src="https://github.com/user-attachments/assets/e99e807f-9ac2-4753-af6a-8865b2222122" /></p>

- Restored background for connection icons: <p align="center">
<img width="113" alt="{B8C7B820-B5A1-4E50-967E-7CAD97E3337C}" src="https://github.com/user-attachments/assets/dc9c3ad1-d0a8-4984-a1ea-7359a0b97d8f" /> </p>

- Bumped the version to **v2.1.0**.

## Why?

Avatar decorations are designed for Discord's rounded profile pictures and can look visually inconsistent when overlaid on square avatars (see the first screenshot below). By separating profile picture rounding into its own option, users can choose between:

- Square profile pictures,
- Square profile pictures without avatar decorations, or
- Discord's default rounded profile pictures while keeping the rest of the UI unrounded.

## Notes

- `--round-pfp` only applies when `--unrounding: on`.
- `--remove-pfp-decor` is independent and can be enabled regardless of the profile picture style.
- `--unrounding: on` makes profile pictures square by default; `--round-pfp` restores rounded profile pictures while keeping the rest of the UI unrounded.
- The screenshots below show example configurations.

## Profile Picture Configurations

### 1. Square profile pictures (default)
`--unrounding: on;`
`--round-pfp: off`
`--remove-pfp-decor: off`

<img width="308" height="155" alt="Screenshot 2026-07-31 154136" src="https://github.com/user-attachments/assets/812392e3-5421-4c1c-9a9b-bc0f962adea0" />


### 2. Square profile pictures without decorations
`--unrounding: on;`
`--round-pfp: off`
`--remove-pfp-decor: on`

<img width="307" height="155" alt="Screenshot 2026-07-31 154203" src="https://github.com/user-attachments/assets/89b5a994-5e28-465e-be0b-c66f472eec24" />

### 3. Discord default profile pictures
`--unrounding: on;`
`--round-pfp: on`
`--remove-pfp-decor: off`

<img width="307" height="155" alt="{E2B5F10A-1E37-4684-90E1-B1F1D82BD617}" src="https://github.com/user-attachments/assets/67a0ae67-1ddd-473a-904f-78e80a84cfd3" />

<br><br>Closes #165 Fixes #135 Fixes #197
<br>If anyone would like to try it out, here's the link to the preview release: https://github.com/infpdev/system24/releases/tag/v2.1.0-pr195-build

Hope you like the changes :]